### PR TITLE
[Breaking] match `make‑arrow‑function` and `make‑async‑function`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 'use strict';
 
-module.exports = function getGeneratorFunctions() {
-	var generatorFuncs = [];
+var getGenerators = function getGeneratorFunctions() {
+	return [
+		'return function* () { var x = yield; return x || 42; }',
+		'return function* gen() { var x = yield; return x || 42; }',
+		'return { *       concise(  ){ var x = yield; return x || 42; } }.concise;'
+	];
+};
+var generatorFuncs = [];
+var fns = getGenerators();
+for (var i = 0; i < fns.length; ++i) {
 	try {
-		generatorFuncs.push(Function('return function* () { var x = yield; return x || 42; }')());
-	} catch (e) {}
-	try {
-		generatorFuncs.push(Function('return function* gen() { var x = yield; return x || 42; }')());
-	} catch (e) {}
-	try {
-		generatorFuncs.push(Function('return { *       concise(  ){ var x = yield; return x || 42; } }.concise;')());
-	} catch (e) {}
+		generatorFuncs.push(Function(fns[i])());
+	} catch (e) { /**/ }
+}
 
-	return generatorFuncs;
+module.exports = function makeGeneratorFunction() {
+	return generatorFuncs[0];
+};
+module.exports.list = function makeGeneratorFunctions() {
+	return generatorFuncs.slice();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,21 +1,39 @@
 'use strict';
 
 var test = require('tape');
-var forEach = require('for-each');
 var iterate = require('iterate-iterator');
-var generators = require('../')();
+var makeGeneratorFunction = require('../');
 
-test('generators supported', { skip: generators.length === 0 }, function (t) {
-	forEach(generators, function (genFunction) {
-		t.comment('genFunction: `' + genFunction + '`');
+test('makeGeneratorFunction() is undefined or a generator function', function (t) {
+	var genFunction = makeGeneratorFunction();
+	if (genFunction) {
 		t.equal(typeof genFunction, 'function', 'genFunction is function');
-		t.deepEqual(iterate(genFunction()), [undefined], 'generator yields expected values');
-	});
-
+		t.equal(String(genFunction), 'function* () { var x = yield; return x || 42; }', 'genFunction has expected source');
+	} else {
+		t.equal(typeof genFunction, 'undefined', 'genFunction is undefined');
+	}
 	t.end();
 });
 
-test('generators not supported', { skip: generators.length > 0 }, function (t) {
-	t.deepEqual(generators, [], 'no generator functions');
+test('makeGeneratorFunction.list() is an array', function (t) {
+	var generators = makeGeneratorFunction.list();
+	var expectedSources = [
+		'function* () { var x = yield; return x || 42; }',
+		'function* gen() { var x = yield; return x || 42; }',
+		'*       concise(  ){ var x = yield; return x || 42; }'
+	];
+	t.plan(1 + (3 * generators.length));
+	t.equal(Object.prototype.toString.call(generators), '[object Array]', 'list() is an array');
+	if (generators.length === 0) {
+		t.comment('no generator functions present');
+	} else {
+		for (var i = 0; i < generators.length; ++i) {
+			var genFunction = generators[i];
+			t.comment('genFunction: `' + genFunction + '`');
+			t.equal(typeof genFunction, 'function', 'genFunction is a function');
+			t.equal(String(genFunction), expectedSources[i], 'String(genFunction) === "' + expectedSources[i] + '"');
+			t.deepEqual(iterate(genFunction()), [undefined], 'generator yields expected values');
+		}
+	}
 	t.end();
 });


### PR DESCRIPTION
This changes the exported interface to match [`make‑arrow‑function`](https://github.com/ljharb/make-arrow-function) and [`make‑async‑function`](https://github.com/ljharb/make-async-function).